### PR TITLE
Add support for CLOs (Cauciones)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .nyc_output/
 node_modules/
 package-lock.json
+.env
+.eslintrc.*

--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ module.exports = class BullMarket {
     return this.api('/Operations/StockAccountQueries/GetScreen?stockAccountNumber=' + stockAccountNumber)
   }
 
-  async fixOrder (stockAccountNumber, { symbol, amount, type, term, side, quantity, securityType, price, stopPrice } = {}) {
+  async fixOrder (stockAccountNumber, { symbol, amount, type, term, side, quantity, securityType, price, stopPrice, settleDate, market = 'BYMA' } = {}) {
     amount = parseFloat(amount)
     if (Number.isNaN(amount)) throw new Error('Invalid amount')
 
@@ -162,12 +162,16 @@ module.exports = class BullMarket {
 
     const settlType = encodeTerm(term)
 
-    side = side === 'buy' ? 1 : 2
+    let side;
+    if (market === 'BYMA')  side = side === 'buy' ? 1 : 2
+    else if (market === 'QS') side = 2
+    else throw new Error('Invalid market type')
 
     const output = await this.api('/Operations/Orders/FixOrder', {
       requestType: 'url',
       body: {
-        market: 'BYMA',
+        market,
+        settleDate,
         account: stockAccountNumber,
         amount: encodeURIComponent(amount.toString().replace('.', ',')),
         orderType, // 1 = market, 2 = limit, 4 = limit with stop

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const SEP = '\x1e'
 
 const GROUPS = ['merval', 'panel general', 'cedears', 'opciones', 'bonos']
 const ORDER_TYPES = { market: 1, limit: 2, stop: 4 }
+const MARKET_TYPES = ['BYMA', 'QS']
 
 module.exports = class BullMarket {
   constructor (opts = {}) {
@@ -160,40 +161,42 @@ module.exports = class BullMarket {
     const orderType = ORDER_TYPES[type]
     if (!orderType) throw new Error('Invalid order type')
 
-    const settlType = encodeTerm(term)
+    if (!MARKET_TYPES.includes(market)) throw new Error('Invalid market type')
 
-    let side;
-    if (market === 'BYMA')  side = side === 'buy' ? 1 : 2
-    else if (market === 'QS') side = 2
-    else throw new Error('Invalid market type')
+    const body = {
+      market,
+      account: stockAccountNumber,
+      amount: encodeURIComponent(amount.toString().replace('.', ',')),
+      orderType, // 1 = market, 2 = limit, 4 = limit with stop
+      securityType, // CS = local stock, CD = foreign stock, GO = bonds
+      symbol,
+      timeInForce: 0,
+      expireDate: '',
+      currency: 'ARS',
+      quantity,
+      settleDate: '',
+      source: '',
+      referralLink: '',
+      regulationAccepted: false,
+      price: encodeURIComponent((price || '').toString().replace('.', ',')), // Limit price
+      stopPrice: encodeURIComponent((stopPrice || '').toString().replace('.', ',')), // Stop price
+      send: true,
+      forceOrder: false,
+      orderCapacity: 'B',
+      minimumOperationValue: ''
+    }
+
+    if (market === 'BYMA') {
+      body.side = side === 'buy' ? 1 : 2
+      body.settlType = encodeTerm(term)
+    } else if (market === 'QS') {
+      body.side = 2 // 2 = place
+      body.settleDate = settleDate
+    }
 
     const output = await this.api('/Operations/Orders/FixOrder', {
       requestType: 'url',
-      body: {
-        market,
-        settleDate,
-        account: stockAccountNumber,
-        amount: encodeURIComponent(amount.toString().replace('.', ',')),
-        orderType, // 1 = market, 2 = limit, 4 = limit with stop
-        securityType, // CS = local stock, CD = foreign stock, GO = bonds
-        symbol,
-        settlType, // 1 = CI, 3 = 48hs
-        timeInForce: 0,
-        expireDate: '',
-        side, // 1 = buy, 2 = sell
-        currency: 'ARS',
-        quantity,
-        settleDate: '',
-        source: '',
-        referralLink: '',
-        regulationAccepted: false,
-        price: encodeURIComponent((price || '').toString().replace('.', ',')), // Limit price
-        stopPrice: encodeURIComponent((stopPrice || '').toString().replace('.', ',')), // Stop price
-        send: true,
-        forceOrder: false,
-        orderCapacity: 'B',
-        minimumOperationValue: ''
-      }
+      body
     })
 
     if (output?.result !== true) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "brittle": "^3.1.3",
+    "dotenv": "^16.4.5",
     "standard": "^17.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const test = require('brittle')
 const BullMarket = require('./index.js')
 
@@ -626,4 +627,29 @@ test('hub - connect and disconnect multiple times', async function (t) {
   } catch (err) {
     t.pass(err.message)
   }
+})
+
+test.skip('publish cto', async function (t) {
+  const broker = new BullMarket({
+    email: process.env.EMAIL,
+    password: process.env.PASSWORD,
+    fingerprint: process.env.FINGERPRINT
+  })
+
+  await broker.login()
+  const stockAccounts = await broker.getStockAccounts()
+
+  const order = await broker.fixOrder(stockAccounts[0].number, {
+    market: 'QS',
+    type: 'market',
+    settleDate: '2024-04-03',
+    symbol: 'PESOS',
+    quantity: 1,
+    amount: 1
+  })
+
+  t.is(order.result, true)
+  t.is(order.assetCompromised, 0)
+
+  await broker.logout()
 })

--- a/test.js
+++ b/test.js
@@ -629,7 +629,7 @@ test('hub - connect and disconnect multiple times', async function (t) {
   }
 })
 
-test.skip('publish cto', async function (t) {
+test.skip('publish CLO', async function (t) {
   const broker = new BullMarket({
     email: process.env.EMAIL,
     password: process.env.PASSWORD,


### PR DESCRIPTION
Allow placing CLOs like so:
```js
  const order = await broker.fixOrder(stockAccountNumber, {
    market: 'QS',
    type: 'market',
    settleDate: '2024-04-03',
    symbol: 'PESOS',
    quantity: 1,
    amount: 1
  })
  ```